### PR TITLE
Fix question card visibility after restarting the flow

### DIFF
--- a/app.js
+++ b/app.js
@@ -493,7 +493,7 @@ document.addEventListener('DOMContentLoaded', () => {
       state.responses = [];
       ui.results.classList.add('hidden');
       ui.restart.classList.add('hidden');
-      ui.questionCard.classList.remove('hidden');
+      ui.questionCard.classList.remove('hidden', 'leaving', 'entering');
       ui.progressShell.classList.remove('hidden');
       renderers.question(QUESTIONNAIRE[state.stepIndex]);
       calculations.updateProgress();


### PR DESCRIPTION
## Summary
- clear lingering animation classes on the question card when restarting the questionnaire so it becomes visible again

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c8fb554f94832f90e5e8ce6bc9c466